### PR TITLE
Need to import subr-x for macro expansion with straight

### DIFF
--- a/edit-as-format.el
+++ b/edit-as-format.el
@@ -28,6 +28,7 @@
 
 ;;; Code:
 (require 'edit-indirect)
+(eval-when-compile (require 'subr-x))
 
 (defgroup edit-as-format nil
   "Edit document as other format"


### PR DESCRIPTION
Without the fix, edit-as-format installed via straight generates an error